### PR TITLE
chore: add new elixir and otp versions to CI matrix

### DIFF
--- a/templates/.github/workflows/ci.yaml
+++ b/templates/.github/workflows/ci.yaml
@@ -133,5 +133,9 @@ jobs:
             otp: 25
           - elixir: 1.15
             otp: 26
+          - elixir: 1.16
+            otp: 26
+          - elixir: 1.16
+            otp: 27
 
 {{/if}}


### PR DESCRIPTION
Adds elixir 1.16 and otp 27 to the testing matrix.