### PR TITLE
chore: update elixir and otp ci matrix

### DIFF
--- a/templates/.github/workflows/ci.yaml
+++ b/templates/.github/workflows/ci.yaml
@@ -127,15 +127,13 @@ jobs:
       fail-fast: false
       matrix:
         versions:
-          - elixir: 1.13
-            otp: 25
           - elixir: 1.14
             otp: 25
           - elixir: 1.15
             otp: 26
           - elixir: 1.16
             otp: 26
-          - elixir: 1.16
+          - elixir: 1.17
             otp: 27
 
 {{/if}}

--- a/templates/.github/workflows/ci.yaml
+++ b/templates/.github/workflows/ci.yaml
@@ -127,8 +127,6 @@ jobs:
       fail-fast: false
       matrix:
         versions:
-          - elixir: 1.14
-            otp: 25
           - elixir: 1.15
             otp: 26
           - elixir: 1.16


### PR DESCRIPTION
Elixir 1.17 is required for OTP 27. Also drops old Elixir 1.13 support cause it's oooooold.