### PR TITLE
fix: add refactor to semver title

### DIFF
--- a/templates/.github/workflows/pr.yaml
+++ b/templates/.github/workflows/pr.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Check
         uses: stordco/actions-pr-title@v1.0.0
         with:
-          regex: '^(feat!|fix!|fix|feat|chore)(\(\w+\))?:\s(\[#\d{1,5}\])?.*$'
+          regex: '^(refactor!|feat!|fix!|refactor|fix|feat|chore)(\(\w+\))?:\s(\[#\d{1,5}\])?.*$'
           hint: |
             Your PR title does not match the Conventional Commits convention. Please rename your PR to match one of the following formats:
 
@@ -31,5 +31,13 @@ jobs:
             chore: update some action
 
             Note: Adding ! (i.e. `feat!:`) represents a breaking change and will result in a SemVer major release.
+
+            Please use one of the following types:
+
+            - **feat:** A new feature, resulting in a MINOR version bump."
+            - **fix:** A bug fix, resulting in a PATCH version bump."
+            - **refactor:** A code change that neither fixes a bug nor adds a feature, resulting in a PATCH version bump."
+            - **chore:** Changes unrelated to the release code, resulting in no version bump."
+            - **revert:** Reverts a previous commit."
 
             See https://www.conventionalcommits.org/en/v1.0.0/ for more information.


### PR DESCRIPTION
Hey @doomspork 

It is still in WIP, but I would like to propose using `refactor` and distinguishing it from `chore.`

In a nutshell, `refactor` causes a SemVer bump, while `chore` is a fallback to anything that is not causing a SemVer change.

I do not have strong opinions; just trying to find a common ground to provide library authors to merge things following SemVer that wouldn't cause a release version change, such as CI, Docs (although I am following up on republishing docs-only), and many other things.