### PR TITLE
feat: Add .tool-version to common config

### DIFF
--- a/templates/.tool-versions
+++ b/templates/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.16
+erlang 26.0


### PR DESCRIPTION
@btkostner see any reason this is a bad idea? I figure it makes it easier for folks supporting these packages to work on the same version across all of them.