### PR TITLE
feat: add stale workflow

### DIFF
--- a/templates/.github/workflows/stale.yaml
+++ b/templates/.github/workflows/stale.yaml
@@ -1,0 +1,47 @@
+name: "Close stale issues and PRs"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 1 * * *"
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 15
+          days-before-pr-stale: 60
+          days-before-pr-close: 60
+
+          stale-issue-label: "stale:discard"
+          exempt-issue-labels: "stale:keep"
+          stale-issue-message: >
+            This issue has been automatically marked as "stale:discard". We are sorry that we haven't been able to
+            prioritize it yet.
+
+            If this issue still relevant, please leave any comment if you have any new additional information that
+            helps to solve this issue. We encourage you to create a pull request, if you can. We are happy to help you
+            with that.
+
+          close-issue-message: >
+            Closing this issue after a prolonged period of inactivity. If this issue is still relevant, feel free to
+            re-open the issue. Thank you!
+
+          stale-pr-label: "stale:discard"
+          exempt-pr-labels: "stale:keep"
+          stale-pr-message: >
+            This pull request has been automatically marked as "stale:discard". **If this pull request is still
+            relevant, please leave any comment** (for example, "bump"), and we'll keep it open. We are sorry that we
+            haven't been able to prioritize reviewing it yet.
+            Your contribution is very much appreciated!.
+          close-pr-message: >
+            Closing this pull request after a prolonged period of inactivity. If this issue is still relevant, please
+            ask for this pull request to be reopened. Thank you!


### PR DESCRIPTION
## Context

@doomspork, as we spoke, adding such a workflow will help with the backlog. We should get some ownership from everyone (maintainers and users) to take ownership of the issues and/or pull requests.

Since it is GitHub, the history will always be there in case we didn't react on time.