### PR TITLE
fix: sync elixir versions, add usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ Currently at version `1.5.0`
 - `scripts` contains javascript and elixir scripts that are ran on each repository. These could be as simple as copying a file to the repository, or as advanced as changing the `mix.exs` AST to update dependencies.
 
 - `templates` contains files that are copied or templated to the repository.
+
+## Usage
+
+- Copy [./templates/.github/workflows/common-config.yaml](./templates/.github/workflows/common-config.yaml) file into your repo's `/.github/workflows/` directory.
+- Create a PR
+- On initial merge and on a [recurring schedule](./templates/.github/workflows/common-config.yaml#L15), updates will be synced with this repository.

--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ Currently at version `1.5.0`
 ## Usage
 
 - Copy [./templates/.github/workflows/common-config.yaml](./templates/.github/workflows/common-config.yaml) file into your repo's `/.github/workflows/` directory.
-- Create a PR
+- Alter your template file by replacing `$\{{` with `${{`.
+- Create a PR.
 - On initial merge and on a [recurring schedule](./templates/.github/workflows/common-config.yaml#L15), updates will be synced with this repository.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ Currently at version `1.5.0`
 ## Usage
 
 - Copy [./templates/.github/workflows/common-config.yaml](./templates/.github/workflows/common-config.yaml) file into your repo's `/.github/workflows/` directory.
-- Alter your template file by replacing `$\{{` with `${{`.
+- Alter your common-config.yaml file by replacing `$\{{` with `${{`.
 - Create a PR.
 - On initial merge and on a [recurring schedule](./templates/.github/workflows/common-config.yaml#L15), updates will be synced with this repository.

--- a/templates/.github/workflows/common-config.yaml
+++ b/templates/.github/workflows/common-config.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: stordco/actions-elixir/setup@v1
         with:
           github-token: $\{{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          elixir-version: "1.15"
+          elixir-version: "1.16"
           otp-version: "26.0"
 
       - name: Sync


### PR DESCRIPTION
Adds a section to the Readme about how to use this common config.

The tool-versions is on elixir 1.16, updates the common config to match that 

https://github.com/beam-community/common-config/blob/main/templates/.tool-versions
https://github.com/beam-community/common-config/blob/main/templates/.github/workflows/common-config.yaml#L41