### PR TITLE
feat: add hex publish docs github action

### DIFF
--- a/templates/.github/workflows/publish-docs.yaml
+++ b/templates/.github/workflows/publish-docs.yaml
@@ -1,22 +1,19 @@
 # This file is synced with beam-community/common-config. Any changes will be overwritten.
 
-name: Production
+name: Publish Docs
 
 on:
-  release:
-    types:
-      - released
-      - prereleased
   workflow_dispatch:
 
 concurrency:
-  group: Production
+  group: hex-publish-docs
+  cancel-in-progress: true
 
 {{#if IS_MIX_PACKAGE}}
 jobs:
   Hex:
     runs-on: ubuntu-latest
-
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,11 +23,8 @@ jobs:
         with:
           github-token: $\{{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
-      - name: Compile
-        run: mix compile --docs
-
-      - name: Publish
-        run: mix hex.publish --yes
+      - name: Publish Docs
+        run: mix hex.publish docs --yes
         env:
           HEX_API_KEY: $\{{ secrets.HEX_API_KEY }}
 {{else}}


### PR DESCRIPTION
## Context

This will allow us to trigger publishing docs only from the trunk branch without creating a new release