### PR TITLE
feat: migrate conventional commit enforcement to commitlint

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,24 @@
+extends:
+  - "@commitlint/config-conventional"
+
+rules:
+  type-enum:
+    - 2
+    - always
+    - - feat
+      - fix
+      - docs
+      - style
+      - refactor
+      - perf
+      - test
+      - build
+      - ci
+      - chore
+      - revert
+  subject-case:
+    - 0
+  header-max-length:
+    - 2
+    - always
+    - 100

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,10 +19,10 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: wagoid/commitlint-github-action@v6
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
         with:
           configFile: .commitlintrc.yml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,23 +10,19 @@ on:
       - synchronize
 
 jobs:
-  title:
-    name: Check Title
+  Commits:
+    name: Conventional Commits
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pull-requests: read
+
     steps:
-      - name: Check
-        uses: beam-community/actions-pr-title@v1.0.0
+      - uses: actions/checkout@v6
         with:
-          regex: '^(feat!|fix!|fix|feat|chore)(\(\w+\))?:\s(\[#\d{1,5}\])?.*$'
-          hint: |
-            Your PR title does not match the Conventional Commits convention. Please rename your PR to match one of the following formats:
+          fetch-depth: 0
 
-            fix: [#123] some title of the PR
-            fix(scope): [#123] some title of the PR
-            feat: [#1234] some title of the PR
-            chore: update some action
-
-            Note: Adding ! (i.e. `feat!:`) represents a breaking change and will result in a SemVer major release.
-
-            See https://www.conventionalcommits.org/en/v1.0.0/ for more information.
+      - uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: .commitlintrc.yml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - id: release
         name: Release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           command: manifest
           config-file: .github/release-please-config.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - id: release
         name: Release
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           command: manifest
           config-file: .github/release-please-config.json
@@ -26,7 +26,7 @@ jobs:
 
       - if: ${{ steps.release.outputs.release_created }}
         name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ steps.release.outputs.tag_name }}
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,14 @@ This project follows [Conventional Commits](https://www.conventionalcommits.org/
 - `feat:` - New feature (MINOR version bump)
 - `fix:` - Bug fix (PATCH version bump)
 - `refactor:` - Code change without feature/fix (no bump)
+- `docs:` - Documentation changes (no bump)
+- `style:` - Formatting, whitespace (no bump)
+- `perf:` - Performance improvement (no bump)
+- `test:` - Adding or updating tests (no bump)
+- `build:` - Build system or dependency changes (no bump)
+- `ci:` - CI/CD configuration changes (no bump)
 - `chore:` - Maintenance (no bump, excluded from changelog)
+- `revert:` - Reverts a previous commit (no bump)
 - `feat!:` / `fix!:` / `refactor!:` - Breaking change (MAJOR version bump)
 
 **Examples:**

--- a/templates/.commitlintrc.yml
+++ b/templates/.commitlintrc.yml
@@ -1,0 +1,26 @@
+# This file is synced with beam-community/common-config. Any changes will be overwritten.
+
+extends:
+  - "@commitlint/config-conventional"
+
+rules:
+  type-enum:
+    - 2
+    - always
+    - - feat
+      - fix
+      - docs
+      - style
+      - refactor
+      - perf
+      - test
+      - build
+      - ci
+      - chore
+      - revert
+  subject-case:
+    - 0
+  header-max-length:
+    - 2
+    - always
+    - 100

--- a/templates/.github/workflows/dependabot.yaml
+++ b/templates/.github/workflows/dependabot.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Fetch Metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: $\{{ secrets.GITHUB_TOKEN }}
 

--- a/templates/.github/workflows/dependabot.yaml
+++ b/templates/.github/workflows/dependabot.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Fetch Metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: $\{{ secrets.GITHUB_TOKEN }}
 

--- a/templates/.github/workflows/pr.yaml
+++ b/templates/.github/workflows/pr.yaml
@@ -12,35 +12,54 @@ on:
       - synchronize
 
 jobs:
-  Title:
+  Commits:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    if: $\{{ github.event_name == 'pull_request' }}
+
     permissions:
+      contents: read
       pull-requests: read
 
-    if: $\{{ github.event_name == 'pull_request' }}
-    name: Check Title
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: .commitlintrc.yml
+
+  Labels:
+    name: Assign Labels
     runs-on: ubuntu-latest
+    if: $\{{ github.event_name == 'pull_request' }}
+
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
-      - name: Check
-        uses: beam-community/actions-pr-title@v1.0.0
+      - uses: actions/checkout@v6
+
+      - uses: mauroalderete/action-assign-labels@v1
         with:
-          regex: '^(refactor!|feat!|fix!|refactor|fix|feat|chore)(\(\w+\))?:\s(\[#\d{1,5}\])?.*$'
-          hint: |
-            Your PR title does not match the Conventional Commits convention. Please rename your PR to match one of the following formats:
-
-            fix: [#123] some title of the PR
-            fix(scope): [#123] some title of the PR
-            feat: [#1234] some title of the PR
-            chore: update some action
-
-            Note: Adding ! (i.e. `feat!:`) represents a breaking change and will result in a SemVer major release.
-
-            Please use one of the following types:
-
-            - **feat:** A new feature, resulting in a MINOR version bump.
-            - **fix:** A bug fix, resulting in a PATCH version bump.
-            - **refactor:** A code change that neither fixes a bug nor adds a feature.
-            - **chore:** Changes unrelated to the release code, resulting in no version bump.
-            - **revert:** Reverts a previous commit.
-
-            See https://www.conventionalcommits.org/en/v1.0.0/ for more information.
+          pull-request-number: $\{{ github.event.pull_request.number }}
+          github-token: $\{{ secrets.GITHUB_TOKEN }}
+          conventional-commits: |
+            conventional-commits:
+              - type: 'fix'
+                nouns: ['FIX', 'Fix', 'fix']
+                labels: ['bug']
+              - type: 'feature'
+                nouns: ['FEAT', 'Feat', 'feat']
+                labels: ['feature']
+              - type: 'chore'
+                nouns: ['CHORE', 'Chore', 'chore']
+                labels: ['chore']
+              - type: 'docs'
+                nouns: ['DOCS', 'Docs', 'docs']
+                labels: ['documentation']
+              - type: 'ci'
+                nouns: ['CI', 'Ci', 'ci']
+                labels: ['ci']

--- a/templates/.github/workflows/pr.yaml
+++ b/templates/.github/workflows/pr.yaml
@@ -22,11 +22,11 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: wagoid/commitlint-github-action@v6
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
         with:
           configFile: .commitlintrc.yml
 
@@ -40,9 +40,9 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: mauroalderete/action-assign-labels@v1
+      - uses: mauroalderete/action-assign-labels@671a4ca2da0f900464c58b8b5540a1e07133e915 # v1
         with:
           pull-request-number: $\{{ github.event.pull_request.number }}
           github-token: $\{{ secrets.GITHUB_TOKEN }}

--- a/templates/.github/workflows/release.yaml
+++ b/templates/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - id: release
         name: Release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json

--- a/templates/.github/workflows/release.yaml
+++ b/templates/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - id: release
         name: Release
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json


### PR DESCRIPTION
## Summary

- Bumps `dependabot/fetch-metadata` to v3 and `googleapis/release-please-action` to v5; also corrects the org rename from `google-github-actions/` to `googleapis/` in the repo's own release workflow
- Replaces the `beam-community/actions-pr-title` regex validator with `wagoid/commitlint-github-action` backed by a `.commitlintrc.yml` config extending `@commitlint/config-conventional`
- Adds a `Labels` job to the PR template that auto-assigns GitHub labels based on commit type (`bug`, `feature`, `chore`, `documentation`, `ci`)

## Complexity Notes

The previous approach validated only the PR title against a hardcoded regex. The new approach validates every commit message in the PR. Repos that land messy interim commits (fixups, WIPs) will see failures — those authors will need to squash or reword before merging.

`subject-case` enforcement is explicitly disabled (`- 0`) because this org uses sentence-case subjects (e.g. `feat: Add Valkey support`) rather than the lower-case default from `@commitlint/config-conventional`.

## Test Steps

1. Sync the updated template to a downstream repo
2. Open a PR with a commit message using a valid type (e.g. `feat: add something`) — the `Commits` job should pass
3. Open a PR with an invalid type (e.g. `wip: something`) — the `Commits` job should fail with a clear commitlint error
4. Confirm the `Labels` job assigns the correct label based on the commit type

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated (`CLAUDE.md` type list expanded)