### PR TITLE
ci: add renovate to update template workflow dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,18 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: ['config:recommended'],
+  // Dependabot cannot scan workflow files outside the repo root .github/workflows,
+  // so Renovate handles the synced templates while Dependabot keeps the repo's own workflows.
+  enabledManagers: ['github-actions'],
+  'github-actions': {
+    managerFilePatterns: ['/^templates/\\.github/workflows/.+\\.ya?ml$/'],
+  },
+  packageRules: [
+    {
+      matchFileNames: ['.github/workflows/**'],
+      enabled: false,
+    },
+  ],
+  // Match the 7-day cooldown used by the Dependabot config
+  minimumReleaseAge: '7 days',
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['config:recommended'],
+  // Monthly so updates land before the downstream sync on the 8th of each month
+  extends: ['config:recommended', 'schedule:monthly'],
   // Dependabot cannot scan workflow files outside the repo root .github/workflows,
   // so Renovate handles the synced templates while Dependabot keeps the repo's own workflows.
   enabledManagers: ['github-actions'],


### PR DESCRIPTION
- Dependabot's `github-actions` ecosystem only scans the repository root `.github/workflows`, so the `/templates` entry in `dependabot.yml` never produced updates and the template action versions drifted behind (e.g. `actions/checkout` is still on v6 while the repo's own workflows are on v7).
- Renovate can target arbitrary paths, so it takes over just `templates/.github/workflows` while Dependabot keeps handling the repo's own workflows, keeping downstream repos on current action versions through the regular sync.
- Verified with a local Renovate dry-run: it picks up all 8 template workflows (including the handlebars-templated ones), proposes `actions/checkout` v6 to v7, a digest bump for the SHA-pinned checkout, and a `node-version` bump, and touches no files outside `templates/`.

Note: this only takes effect once the Mend Renovate GitHub App is installed on this repository.