### PR TITLE
fix(renovate): trigger releases for template dependency bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,11 @@
       matchFileNames: ['.github/workflows/**'],
       enabled: false,
     },
+    {
+      // Templates are synced to downstream repos, so bumps must trigger a release
+      matchFileNames: ['templates/**'],
+      semanticCommitType: 'fix',
+    },
   ],
   // Match the 7-day cooldown used by the Dependabot config
   minimumReleaseAge: '7 days',


### PR DESCRIPTION
- Renovate PRs touching `templates/` were tagged as `chore`, so Release Please never picked up those bumps as a release-worthy change downstream.