### PR TITLE
fix: detect public package function head in mix.exs

### DIFF
--- a/scripts/001.detect-elixir-package.sh
+++ b/scripts/001.detect-elixir-package.sh
@@ -3,7 +3,7 @@
 if [ -f "mix.exs" ]; then
   echo "mix.exs file detected"
 
-  if grep -q "defp package do" mix.exs; then
+  if grep -qE "defp? package do" mix.exs; then
     echo "Detected a package function head in mix.exs"
     echo "IS_MIX_PACKAGE=true" >> "$TEMPLATE_ENV"
 


### PR DESCRIPTION
- Package detection only matched `defp package do`, so repos exposing a public `package` function were treated as non-packages and got invalid `jobs: {}` publish/production workflows synced down.