### PR TITLE
chore(deps): remove dead dependabot templates entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,3 @@ updates:
       prefix: "chore(deps)"
     cooldown:
       default-days: 7
-
-  - package-ecosystem: github-actions
-    directory: "/templates"
-    schedule:
-      interval: weekly
-    commit-message:
-      prefix: "chore(deps)"
-    cooldown:
-      default-days: 7


### PR DESCRIPTION
- Dependabot's github-actions ecosystem only scans the repo-root .github/workflows, so this /templates entry has never produced an update since Renovate took over templates/.github/workflows in #89 (see that PR's description). Leaving dead config in place invites confusion and risks duplicate PRs against Renovate if GitHub ever changes that scanning behavior.