### PR TITLE
fix: close downstream dependabot PRs for common-config-managed files only

### DIFF
--- a/templates/.github/dependabot.yml
+++ b/templates/.github/dependabot.yml
@@ -1,14 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: weekly
-    commit-message:
-      prefix: "chore(deps)"
-    cooldown:
-      default-days: 7
-
   - package-ecosystem: mix
     directory: "/"
     schedule:

--- a/templates/.github/dependabot.yml
+++ b/templates/.github/dependabot.yml
@@ -1,5 +1,14 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: mix
     directory: "/"
     schedule:

--- a/templates/.github/workflows/dependabot.yaml
+++ b/templates/.github/workflows/dependabot.yaml
@@ -19,20 +19,53 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: $\{{ github.event.pull_request.head.sha }}
+
       - name: Fetch Metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: $\{{ secrets.GITHUB_TOKEN }}
 
+      - name: Check for common-config-managed files
+        id: managed
+        if: steps.metadata.outputs.package-ecosystem == 'github_actions'
+        run: |
+          all_managed=true
+
+          while IFS= read -r file; do
+            if [ ! -f "$file" ] || ! grep -q "synced with beam-community/common-config" "$file"; then
+              all_managed=false
+              break
+            fi
+          done < <(gh pr view "$PR_URL" --json files --jq '.files[].path')
+
+          echo "all_managed=$all_managed" >> "$GITHUB_OUTPUT"
+        env:
+          PR_URL: $\{{ github.event.pull_request.html_url }}
+          GH_TOKEN: $\{{ secrets.GITHUB_TOKEN }}
+
+      - name: Close PR for common-config-managed files
+        if: steps.managed.outputs.all_managed == 'true'
+        run: |
+          gh pr comment "$PR_URL" --body "Every file this PR touches is synced from beam-community/common-config, so this update has to land there and flow down through the regular sync instead. Closing in favor of that."
+          gh pr close "$PR_URL"
+        env:
+          PR_URL: $\{{ github.event.pull_request.html_url }}
+          GH_TOKEN: $\{{ secrets.GITHUB_TOKEN }}
+
       - name: Approve PR
+        if: steps.managed.outputs.all_managed != 'true'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: $\{{ github.event.pull_request.html_url }}
           GH_TOKEN: $\{{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for patch and minor updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.dependency-type == 'direct:production'
+        if: steps.managed.outputs.all_managed != 'true' && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.dependency-type == 'direct:production')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: $\{{ github.event.pull_request.html_url }}

--- a/templates/.github/workflows/stale.yaml
+++ b/templates/.github/workflows/stale.yaml
@@ -1,3 +1,5 @@
+# This file is synced with beam-community/common-config. Any changes will be overwritten.
+
 name: "Close stale issues and PRs"
 
 on:


### PR DESCRIPTION
- Downstream repos get templates/.github/workflows synced in as-is, and Dependabot's github-actions ecosystem can't be scoped to exclude specific files, so it was opening PRs bumping actions in workflow files that common-config itself owns and overwrites on every sync (see beam-community/jsonapi#458), conflicting with or getting reverted by the next sync instead of ever landing.
- Downstream repos still need github-actions Dependabot active for any workflows they add on their own, so instead of disabling the ecosystem entirely, the synced auto-merge workflow now detects PRs that touch only common-config-managed files (marked with the "synced with beam-community/common-config" header) and closes them, routing those bumps through common-config's own release + sync instead.