### PR TITLE
fix(workflows): scope concurrency per pull request and guard manual publish

### DIFF
--- a/templates/.github/workflows/ci.yaml
+++ b/templates/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: CI $\{{ github.head_ref || github.run_id }}
+  group: CI $\{{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/templates/.github/workflows/production.yaml
+++ b/templates/.github/workflows/production.yaml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   Hex:
     runs-on: ubuntu-latest
+    if: github.event_name == 'release' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
 
     steps:
       - name: Checkout

--- a/templates/.github/workflows/publish-docs.yaml
+++ b/templates/.github/workflows/publish-docs.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   Hex:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
- `github.head_ref` is the unqualified branch name, so two fork pull requests that both use a branch name like `patch-1` share a concurrency group and cancel each other. `patch-1` is what GitHub picks by default when a contributor edits a file through the web UI on a fork, so this is reachable in any repository that takes drive-by contributions.
- The Hex publish accepted `workflow_dispatch` with no ref guard, so a manual run could be started from any branch or tag and would push that checkout with `mix hex.publish --yes`. Publishing to Hex is not reversible, and this template ships to every mix package in the organisation.
- The docs publish was already guarded, which shows the intent, but it hardcoded `refs/heads/main` and so silently skips in any downstream repository whose default branch is named something else.
