### PR TITLE
fix(commitlint): allow the long lines dependabot always emits

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -22,3 +22,7 @@ rules:
     - 2
     - always
     - 100
+  body-max-line-length:
+    - 0
+  footer-max-line-length:
+    - 0

--- a/templates/.commitlintrc.yml
+++ b/templates/.commitlintrc.yml
@@ -24,3 +24,7 @@ rules:
     - 2
     - always
     - 100
+  body-max-line-length:
+    - 0
+  footer-max-line-length:
+    - 0


### PR DESCRIPTION
- Every repository synced from this template fails its own Conventional Commits check on dependency PRs, because Dependabot embeds compare URLs that are structurally longer than the 100 character default and no rewording can shorten them.
- The check was therefore impossible to satisfy rather than merely strict, which blocks the dependency updates the template is meant to automate.
- Reproduced in elixir-tesla/tesla and verified against real Dependabot commit messages for both the github-actions and mix ecosystems.