### PR TITLE
fix(pr): skip label assignment on pull requests from forks

### DIFF
--- a/templates/.github/workflows/pr.yaml
+++ b/templates/.github/workflows/pr.yaml
@@ -33,7 +33,7 @@ jobs:
   Labels:
     name: Assign Labels
     runs-on: ubuntu-latest
-    if: $\{{ github.event_name == 'pull_request' }}
+    if: $\{{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
 
     permissions:
       contents: read


### PR DESCRIPTION
- Fork pull requests are given a read-only `GITHUB_TOKEN` no matter what the workflow's `permissions` block asks for, so the labeling call returns `403 Resource not accessible by integration` and the job can never pass
- Every repository syncing this template therefore shows a permanently failing check on every external contribution, which reads as "your PR is broken" to people who have no way to fix it and nothing to do with their change
- Labeling still runs for same-repository pull requests, where the token does carry write access
- `pull_request_target` would restore labeling on forks too, but it is not worth handing a write-scoped token to a third-party action on untrusted pull requests for something cosmetic